### PR TITLE
Add readme and fix vpn script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+(c) Copyright 2021 Imam Omar Mochtar.
+
+Licensed under the MIT license:
+
+    http://www.opensource.org/licenses/mit-license.php
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+A cmd app for generating combination between a content (it can be a password) with totp token. The implementation can be seen in [example](example/) directory.
+
+**Use with your own risk !!!**
+
+# Installing
+
+You can download the (compressed) static binary in [release page](https://github.com/iomarmochtar/content-plus-totp/releases)
+
+## Compiling
+
+- Clone this repository.
+
+- Make sure you have `make` and `go` configured properly.
+
+- Compile it, the static binary output will be created in `dist` directory.
+
+```bash
+make compile
+```
+
+# Configuration
+
+Run following command for generating json configuration file, the contents are protected using `AES` encryption make sure to remember the key otherwise you cannot decrypt it.
+
+```bash
+content-plus-totp -g
+```
+
+**note:** You can add `-b` for copy the output directly to clipboard.
+
+
+# Executing
+
+Generate the combination by run the cmd directly with specified configuration.
+
+```bash
+content-plus-totp -c config.json
+```
+
+**note:** You can add `-b` for copy the output directly to clipboard.
+
+

--- a/example/vpn_totp_auth.sh
+++ b/example/vpn_totp_auth.sh
@@ -6,10 +6,15 @@ user=$1
 config=$2
 vpnProfile=$3
 
+TEMP=$(mktemp)
+echo $user > $TEMP
+
 result=$(content-plus-totp -c $config)
 if [ $? != 0 ]; then
   echo "cannot be proceed, read above read message for more details"
   exit 1
 fi
 
-sudo bash -c "openvpn --config ${vpnProfile} --auth-user-pass <(echo -e \"${user}${result}\")"
+echo $result >> $TEMP
+(sleep 3 && rm -rf $TEMP)&
+sudo openvpn --config ${vpnProfile} --auth-user-pass ${TEMP}


### PR DESCRIPTION
the VPN script potentially can leak the credential once the detail process through command `ps aufx` is executed.